### PR TITLE
Update keypress "g" url

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -45,7 +45,7 @@ class App extends React.Component {
 
     window.addEventListener('keydown', (e) => {
       if (e.keyCode === 71) {
-        window.open('https://github.com/');
+        window.open('https://github.com/MariuszDabrowski/ac-miles');
       }
 
       if ((e.keyCode === 27 || e.keyCode === 66) && this.state.carouselActive) {


### PR DESCRIPTION
Right now the link to Github links to this repository, which is great! But the keypress for it links to the main Github homepage. This just updates it to also go to this repository. Thanks for making this site, I love it!